### PR TITLE
Support for old Basket field

### DIFF
--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -36,6 +36,17 @@ class DirectGateway extends AbstractGateway
     {
         return $this->setParameter('vendor', $value);
     }
+    
+    public function setUseOldBasketFormat($value){
+        $value = (bool)$value;
+        return $this->setParameter('useOldBasketFormat', $value);
+    }
+
+    public function getUseOldBasketFormat(){
+        $var = $this->getParameter('useOldBasketFormat');
+        if(!empty($var)) return true;
+        return false;
+    }
 
     // Access to the HTTP client for debugging.
     // NOTE: this is likely to be removed or replaced with something

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -37,12 +37,15 @@ class DirectGateway extends AbstractGateway
         return $this->setParameter('vendor', $value);
     }
     
-    public function setUseOldBasketFormat($value){
+    public function setUseOldBasketFormat($value)
+    {
         $value = (bool)$value;
+
         return $this->setParameter('useOldBasketFormat', $value);
     }
 
-    public function getUseOldBasketFormat(){
+    public function getUseOldBasketFormat()
+    {
         return $this->getParameter('useOldBasketFormat');
     }
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -27,12 +27,15 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->action;
     }
     
-    public function setUseOldBasketFormat($value){
+    public function setUseOldBasketFormat($value)
+    {
         $value = (bool)$value;
+
         return $this->setParameter('useOldBasketFormat', $value);
     }
 
-    public function getUseOldBasketFormat(){
+    public function getUseOldBasketFormat()
+    {
         return $this->getParameter('useOldBasketFormat');
     }
 
@@ -250,13 +253,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      * 1:Item:2:10.00:0.00:10.00:20.00
      * [number of lines]:[item name]:[quantity]:[unit cost]:[item tax]:[item total]:[line total]
      */
-    protected function getItemDataNonXML(){
+    protected function getItemDataNonXML()
+    {
 
         $result = '';
         $items = $this->getItems();
         $count = 0;
 
-        foreach($items as $basketItem){
+        foreach ($items as $basketItem) {
             $lineTotal = ($basketItem->getQuantity() * $basketItem->getPrice());
 
             $description = $this->filterItemName($basketItem->getName());
@@ -276,7 +280,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         }
 
         // Prepend number of lines to the result string
-        $result = $count.$result;
+        $result = $count . $result;
 
         return $result;
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -26,6 +26,15 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->action;
     }
+    
+    public function setUseOldBasketFormat($value){
+        $value = (bool)$value;
+        return $this->setParameter('useOldBasketFormat', $value);
+    }
+
+    public function getUseOldBasketFormat(){
+        return $this->getParameter('useOldBasketFormat')
+    }
 
     public function getAccountType()
     {

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -33,7 +33,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     public function getUseOldBasketFormat(){
-        return $this->getParameter('useOldBasketFormat')
+        return $this->getParameter('useOldBasketFormat');
     }
 
     public function getAccountType()

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -233,4 +233,43 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
         return $result;
     }
+    
+    /**
+     * Generate Basket string in the old format
+     * This is called if "useOldBasketFormat" is set to true in the gateway config
+     * @return string Basket field in format of:
+     * 1:Item:2:10.00:0.00:10.00:20.00
+     * [number of lines]:[item name]:[quantity]:[unit cost]:[item tax]:[item total]:[line total]
+     */
+    protected function getItemDataNonXML(){
+
+        $result = '';
+        $items = $this->getItems();
+        $count = 0;
+
+        foreach($items as $basketItem){
+            $lineTotal = ($basketItem->getQuantity() * $basketItem->getPrice());
+
+            $description = $this->filterItemName($basketItem->getName());
+            $description = str_replace(':', ' ', $description); // Make sure there aren't any colons in the name
+            // Perhaps : should be replaced with '-' or other symbol?
+
+            $result .= ':' . $description .    // Item name
+                ':' . $basketItem->getQuantity() . // Quantity
+                ':' . number_format($basketItem->getPrice(), 2, '.', '') .    // Unit cost (without tax)
+                ':0.00' .    // Item tax
+                ':' . number_format($basketItem->getPrice(), 2, '.', '') .    // Item total
+                ':' . number_format($lineTotal);  // Line total
+            // As the getItemData() puts 0.00 into tax, same was done here
+
+            $count++;
+
+        }
+
+        // Prepend number of lines to the result string
+        $result = $count.$result;
+
+        return $result;
+
+    }
 }

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -54,12 +54,12 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
 
-        if($this->getUseOldBasketFormat()){
+        if ($this->getUseOldBasketFormat()) {
             $basket = $this->getItemDataNonXML();
-            if(!empty($basket)){
+            if (!empty($basket)) {
                 $data['Basket'] = $basket;
             }
-        }else{
+        } else {
             $basketXML = $this->getItemData();
             if (!empty($basketXML)) {
                 $data['BasketXML'] = $basketXML;

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -54,9 +54,16 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
 
-        $basketXML = $this->getItemData();
-        if (!empty($basketXML)) {
-            $data['BasketXML'] = $basketXML;
+        if($this->getUseOldBasketFormat()){
+            $basket = $this->getItemDataNonXML();
+            if(!empty($basket)){
+                $data['Basket'] = $basket;
+            }
+        }else{
+            $basketXML = $this->getItemData();
+            if (!empty($basketXML)) {
+                $data['BasketXML'] = $basketXML;
+            }
         }
 
         return $data;


### PR DESCRIPTION
Added setter and getter methods to access "useOldBasketFormat" field from config.
Added a new method to generate the item data in an old, non-xml format.